### PR TITLE
Trajectory Generalization Bug Fix and Improvements

### DIFF
--- a/2.12/trajectory_generalization/scripts/compute_flows_between_cells_from_trajectories.py
+++ b/2.12/trajectory_generalization/scripts/compute_flows_between_cells_from_trajectories.py
@@ -28,8 +28,10 @@ class SequenceGenerator():
             self.weightIdx = None
         self.sequences = {}
         
-        for traj in trajectory_layer.getFeatures():
+        nTraj = float(trajectory_layer.featureCount())
+        for i,traj in enumerate(trajectory_layer.getFeatures()):
             self.evaluate_trajectory(traj)
+            progress.setPercentage(i/nTraj*100)
             
     def evaluate_trajectory(self,trajectory):
         points = trajectory.geometry().asPolyline()

--- a/2.12/trajectory_generalization/scripts/compute_flows_between_cells_from_trajectories.py
+++ b/2.12/trajectory_generalization/scripts/compute_flows_between_cells_from_trajectories.py
@@ -41,12 +41,12 @@ class SequenceGenerator():
             nearest_cell = self.id_to_centroid[id][0]
             nearest_cell_id = nearest_cell.id()
             prev_cell_id = None
+            if self.weight_field is not None:
+                weight = trajectory.attributes()[self.weightIdx]
+            else:
+                weight = 1
             if len(this_sequence) >= 1:
                 prev_cell_id = this_sequence[-1]
-                if self.weight_field is not None:
-                    weight = trajectory.attributes()[self.weightIdx]
-                else:
-                    weight = 1
                 if self.sequences.has_key((prev_cell_id,nearest_cell_id)):
                     self.sequences[(prev_cell_id,nearest_cell_id)] += weight
                 else:
@@ -56,8 +56,8 @@ class SequenceGenerator():
                 m = trajectory.geometry().geometry().pointN(i).m()
                 t = datetime(1970,1,1) + timedelta(seconds=m) + timedelta(hours=8) # Beijing GMT+8
                 h = t.hour 
-                self.id_to_centroid[id][1][0] = self.id_to_centroid[id][1][0] + 1
-                self.id_to_centroid[id][1][h/6+1] = self.id_to_centroid[id][1][h/6+1] + 1
+                self.id_to_centroid[id][1][0] += weight
+                self.id_to_centroid[id][1][h/6+1] += weight
                 this_sequence.append(nearest_cell_id)
     
     def create_flow_lines(self):

--- a/2.12/trajectory_generalization/scripts/compute_flows_between_cells_from_trajectories.py
+++ b/2.12/trajectory_generalization/scripts/compute_flows_between_cells_from_trajectories.py
@@ -36,21 +36,19 @@ class SequenceGenerator():
     def evaluate_trajectory(self,trajectory):
         points = trajectory.geometry().asPolyline()
         this_sequence = []
+        weight = 1 if self.weight_field is None else trajectory.attributes()[self.weightIdx]
+        prev_cell_id = None
         for i, pt in enumerate(points):
             id = self.cell_index.nearestNeighbor(pt,1)[0]
             nearest_cell = self.id_to_centroid[id][0]
             nearest_cell_id = nearest_cell.id()
-            prev_cell_id = None
-            if self.weight_field is not None:
-                weight = trajectory.attributes()[self.weightIdx]
-            else:
-                weight = 1
             if len(this_sequence) >= 1:
                 prev_cell_id = this_sequence[-1]
-                if self.sequences.has_key((prev_cell_id,nearest_cell_id)):
-                    self.sequences[(prev_cell_id,nearest_cell_id)] += weight
-                else:
-                    self.sequences[(prev_cell_id,nearest_cell_id)] = weight
+                if nearest_cell_id != prev_cell_id:
+                    if self.sequences.has_key((prev_cell_id,nearest_cell_id)):
+                        self.sequences[(prev_cell_id,nearest_cell_id)] += weight
+                    else:
+                        self.sequences[(prev_cell_id,nearest_cell_id)] = weight
             if nearest_cell_id != prev_cell_id: 
                 # we have changed to a new cell --> up the counter 
                 m = trajectory.geometry().geometry().pointN(i).m()

--- a/2.12/trajectory_generalization/scripts/compute_flows_between_cells_from_trajectories.py
+++ b/2.12/trajectory_generalization/scripts/compute_flows_between_cells_from_trajectories.py
@@ -41,7 +41,7 @@ class SequenceGenerator():
             nearest_cell = self.id_to_centroid[id][0]
             nearest_cell_id = nearest_cell.id()
             prev_cell_id = None
-            if len(this_sequence) > 1:
+            if len(this_sequence) >= 1:
                 prev_cell_id = this_sequence[-1]
                 if self.weight_field is not None:
                     weight = trajectory.attributes()[self.weightIdx]


### PR DESCRIPTION
This pull request fixes a bug from upstream in which the first segment of each trajectory was ignored in the flow line calculation (see ec14e40).

In addition, progress reporting was added to compute_flows_between_cells_from_trajectories.py.

Finally, an expansion / bug fix regarding my last pull request (#19). The user-defined weight field (when enabled) is now taken into consideration when calculating the cell counts as well as the flow lines.